### PR TITLE
feat: add login tests for AuthResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
@@ -56,7 +57,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "jest": "^29.5.0",
+    "jest": "^29.7.0",
     "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^6.3.3",
@@ -81,6 +82,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
   }
+}
 }

--- a/src/modules/auth/auth.resolver.spec.ts
+++ b/src/modules/auth/auth.resolver.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { AuthResolver } from './auth.resolver';
+import { UserService } from '../user/user.service';
+import * as bcrypt from 'bcryptjs';
+import { User } from '../user/models/user.entity';
+
+describe('AuthResolver', () => {
+  let resolver: AuthResolver;
+  let userService: UserService;
+  let jwtService: JwtService;
+
+  beforeEach(async () => {
+    // Mock UserService and JwtService
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthResolver,
+        {
+          provide: UserService,
+          useValue: {
+            findByEmail: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<AuthResolver>(AuthResolver);
+    userService = module.get<UserService>(UserService);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  it('should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  describe('login', () => {
+    it('should return error if user does not exist', async () => {
+      jest.spyOn(userService, 'findByEmail').mockResolvedValueOnce(null);
+      expect(await resolver.login('test@example.com', 'password')).toEqual({
+        code: 10002,
+        message: "account doesn't exist",
+      });
+    });
+
+    it('should return error if password is invalid', async () => {
+      jest.spyOn(userService, 'findByEmail').mockResolvedValueOnce({
+        id: 'a9868b30-51bd-4070-8dbb-043a56e21bcb',
+        email: 'wethanw.001@gmail.com',
+        password: 'YourSecurePassword', 
+      } as User);
+
+      jest.spyOn(bcrypt, 'compare' as any).mockResolvedValueOnce(false);
+
+      expect(await resolver.login('test@example.com', 'wrongpassword')).toEqual({
+        code: 10003,
+        message: 'login failed, wrong password',
+      });
+    });
+
+    it('should return token if login is successful', async () => {
+      jest.spyOn(userService, 'findByEmail').mockResolvedValueOnce({ 
+        id: 'a9868b30-51bd-4070-8dbb-043a56e21bcb',
+        email: 'wethanw.001@gmail.com',
+        password: 'YourSecurePassword', 
+    } as User);
+      jest.spyOn(bcrypt, 'compare' as any).mockResolvedValueOnce(true);
+      jest.spyOn(jwtService, 'sign').mockReturnValue('token');
+
+      expect(await resolver.login('test@example.com', 'password')).toEqual({
+        code: 200,
+        message: 'login successful',
+        data: 'token',
+      });
+    });
+  });
+});


### PR DESCRIPTION
Added unit tests for the login functionality in AuthResolver:

- implemented a test to handle non-existent user scenario;

- implemented a test to handle incorrect password scenario;

- implemented a test to verify token generation on successful login;

- mocked UserService and JwtService to simulate the login process.

Resolve CP-26