### PR TITLE
feat: verification email

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^16.3.1",
     "graphql": "^16.8.1",
     "joi": "^17.12.2",
+    "nodemailer": "^6.9.13",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.11.3",

--- a/src/common/constants/code.ts
+++ b/src/common/constants/code.ts
@@ -8,3 +8,5 @@ export const NOT_EMPTY = 10006;
 export const VALIDATE_ERROR = 10007;
 export const UPDATE_PASSWORD_ERROR = 10008;
 export const UNKNOWN_ERROR = 10009;
+export const ACCOUNT_NOT_VERIFIED = 10010;
+export const VERIFY_ERROR = 10011;

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { AuthResolver } from './auth.resolver';
 import { UserService } from '../user/user.service';
 import { JwtStrategy } from './jwt.strategy';
 import { User } from '../user/models/user.entity';
+import { EmailVerificationService } from './email.service';
 
 @Module({
   imports: [
@@ -17,7 +18,14 @@ import { User } from '../user/models/user.entity';
     }),
     TypeOrmModule.forFeature([User]),
   ],
-  providers: [ConsoleLogger, AuthService, AuthResolver, UserService, JwtStrategy],
+  providers: [
+    ConsoleLogger,
+    AuthService,
+    AuthResolver,
+    UserService,
+    JwtStrategy,
+    EmailVerificationService,
+  ],
   exports: [],
 })
 export class AuthModule {}

--- a/src/modules/auth/auth.resolver.ts
+++ b/src/modules/auth/auth.resolver.ts
@@ -10,6 +10,8 @@ import { passwordUpdateSchema } from '@/validation/schemas/auth/password.update'
 import { UpdatePasswordInput } from '../user/dto/update-password.input';
 import { PasswordValidationPipe } from './pipe/password-validation.pipe';
 import { PasswordPipeErrorFilter } from './filter/password-pipe-error.filter';
+import { emailSchema } from '@/common/utils/helpers';
+import { EmailValidationPipe } from './pipe/email-validation.pipe';
 import { GqlAuthGuard } from '@/common/guards/auth.guard';
 
 @Resolver()
@@ -26,6 +28,14 @@ export class AuthResolver {
   @UseFilters(RegisterPipeErrorFilter)
   async register(@Args('input') input: CreateUserInput): Promise<Result> {
     return await this.authService.register(input);
+  }
+
+  @Mutation(() => Result, { description: 'Email Verification' })
+  async verifyEmail(
+    @Args('email', new EmailValidationPipe(emailSchema)) email: string,
+    @Args('token') token: string
+  ): Promise<Result> {
+    return await this.authService.verifyEmail(email, token);
   }
 
   @Mutation(() => Result, { description: 'Change password' })

--- a/src/modules/auth/email.service.ts
+++ b/src/modules/auth/email.service.ts
@@ -1,0 +1,69 @@
+import * as nodemailer from 'nodemailer';
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { User } from '@/modules/user/models/user.entity';
+import { Result } from '@/common/dto/result.type';
+import { REGISTER_ERROR } from '@/common/constants/code';
+
+@Injectable()
+export class EmailVerificationService {
+  constructor(private jwtService: JwtService) {}
+
+  generateVerificationToken(email: string): string {
+    const token = this.jwtService.sign({ email }, { expiresIn: '30m' });
+    return token;
+  }
+
+  async sendVerificationEmail(user: User): Promise<Result> {
+    if (!process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
+      console.error('Email credentials not found.');
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.office365.com',
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+      tls: {
+        ciphers: 'SSLv3',
+        rejectUnauthorized: false,
+      },
+    });
+
+    try {
+      await transporter.verify();
+    } catch (error) {
+      console.error('Failed to connect to email server:', error);
+    }
+
+    // TODO: link will be updated once api server is deployed, currently this url is for local development only
+    const verificationLink = `http://localhost:3010/verify-email?email=${user.email}&token=${user.verificationToken}`;
+    try {
+      await transporter.sendMail({
+        from: process.env.EMAIL_USER,
+        to: user.email,
+        subject: 'Verify Your Email',
+        html: `
+        <div style="font-family: Arial, sans-serif; padding: 20px; color: #007bff">
+          <h2 style="color: #333; text-align: center;">Verify Your Email</h2>
+          <p style="color: #666;">Thank you for signing up with BeeQuant AI! To complete your registration, please click the link below to verify your email address:</p>
+          <div style="text-align: center;">
+            <a href="${verificationLink}" style="display: inline-block; background-color: #007bff; color: #fff; text-decoration: none; padding: 10px 20px; border-radius: 5px; margin-top: 20px;">Verify Email</a>
+          </div>
+          <p style="color: #666; margin-top: 20px;">If you did not request this verification, you can safely ignore this email.</p>
+        </div>
+        
+        `,
+      });
+    } catch (error) {
+      console.error('Failed to send email:', error);
+      return {
+        code: REGISTER_ERROR,
+        message: 'Email verification failed',
+      };
+    }
+  }
+}

--- a/src/modules/auth/pipe/email-validation.pipe.spec.ts
+++ b/src/modules/auth/pipe/email-validation.pipe.spec.ts
@@ -1,0 +1,54 @@
+import { EmailValidationPipe } from './email-validation.pipe';
+import { emailSchema } from '@/common/utils/helpers';
+import { EmptyFiledException } from '@/exceptions/empty-field.exception';
+import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { EmailErrorMsgs } from '@/common/utils/helpers';
+
+describe('EmailValidationPipe', () => {
+  let pipe: EmailValidationPipe;
+
+  beforeEach(() => {
+    pipe = new EmailValidationPipe(emailSchema);
+  });
+
+  it('should return value when validation succeeds', () => {
+    const value = 'valid.email@example.com';
+    expect(pipe.transform(value)).toEqual(value);
+  });
+
+  it('should throw EmptyFiledException when email is missing', () => {
+    const value = '';
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Required);
+  });
+
+  it('should throw InvalidInputException for missing "@" symbol', () => {
+    const value = 'invalidemail.com';
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException for invalid characters', () => {
+    const value = 'user!@example.com';
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException for missing top-level domain', () => {
+    const value = 'user@example';
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException for missing domain part', () => {
+    const value = 'user@';
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException for missing username part', () => {
+    const value = '@example.com';
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
+  });
+});

--- a/src/modules/auth/pipe/email-validation.pipe.ts
+++ b/src/modules/auth/pipe/email-validation.pipe.ts
@@ -1,0 +1,23 @@
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { errorMatcher } from '@/common/utils/errorMatcher';
+import { z, ZodIssue, ZodSchema } from 'zod';
+
+@Injectable()
+export class EmailValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema) {}
+  transform(value: unknown) {
+    try {
+      const parsedValue = this.schema.parse(value);
+      return parsedValue;
+    } catch (error) {
+      const issues: ZodIssue = error.issues;
+      const code: z.ZodIssueCode = issues[0].code;
+      const message: string = issues[0].message;
+      if (code === 'too_small') {
+        const min: number = issues[0].minimum;
+        return errorMatcher({ code, message, min });
+      }
+      return errorMatcher({ code, message });
+    }
+  }
+}

--- a/src/modules/user/dto/update-user.input.ts
+++ b/src/modules/user/dto/update-user.input.ts
@@ -12,4 +12,8 @@ export class UpdateUserInput {
   password?: string;
   @Field({ description: 'Mobile number', nullable: true })
   mobile?: string;
+  @Field({ description: 'is Email Verified', nullable: true })
+  isEmailVerified?: boolean;
+  @Field({ description: 'Verification Token', nullable: true })
+  verificationToken?: string;
 }

--- a/src/modules/user/dto/user.type.ts
+++ b/src/modules/user/dto/user.type.ts
@@ -18,4 +18,8 @@ export class UserType {
   wechat?: string;
   @Field({ description: 'QQ' })
   qq?: string;
+  @Field({ description: 'is Email Verified'})
+  isEmailVerified: boolean;
+  @Field({ description: 'Verification Token', nullable: true })
+  verificationToken?: string;
 }

--- a/src/modules/user/models/user.entity.ts
+++ b/src/modules/user/models/user.entity.ts
@@ -101,6 +101,19 @@ export class User extends CommonEntity {
   })
   captchaCreateAt: Date;
 
+  @Column({
+    comment: 'Whether the email is verified or not',
+    default: false,
+    nullable: true,
+  })
+  isEmailVerified: boolean;
+
+  @Column({
+    comment: 'Verification Token',
+    nullable: true,
+  })
+  verificationToken: string;
+
   @OneToMany(() => ExchangeKey, (key) => key.user)
   keys: ExchangeKey[];
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -30,12 +30,18 @@ export class UserService {
 
   // update an user
   async update(id: string, entity: DeepPartial<User>): Promise<boolean> {
-    const res = await this.userRepository.update(id, entity);
-    console.log(res);
-    if (res.affected > 0) {
+    const found = await this.userRepository.findOne({
+      where: {
+        id,
+      },
+    });
+
+    this.userRepository.merge(found, entity);
+    const res = this.userRepository.save(found);
+
+    if (res) {
       return true;
     }
-    return false;
   }
 
   // get all users

--- a/yarn.lock
+++ b/yarn.lock
@@ -4628,6 +4628,11 @@ node-releases@^2.0.14:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
   integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
+nodemailer@^6.9.13:
+  version "6.9.13"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.13.tgz#5b292bf1e92645f4852ca872c56a6ba6c4a3d3d6"
+  integrity sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==
+
 normalize-path@3.0.0, normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"


### PR DESCRIPTION
Added email verification function
- send verification email after user registration
- a verification email should be sent to the user's provided email address (the email contains a link/button(valid only 30 mins) for email verification)
- verify through email link
- when a new user click on the verification link (”Verify now”) Then a user's account should be verified
- if Link expire, will send another verification email
- if a unverified user attempt to login, will require verification and send verification email

Resolve CP-8

![2024-05-16 11_17_52-README md - platform_api - Visual Studio Code](https://github.com/BeeQuantAI/platform_api/assets/80236130/c2a41089-afe8-4577-a807-4e5ad44a043b)
![2024-05-23 04_43_42-Verify Your Email - rayrunzewang@gmail com - Gmail](https://github.com/BeeQuantAI/platform_api/assets/80236130/dd9b47fb-ffa1-4f77-8f98-c7a52242fad2)
![2024-06-15 11_30_45-Greenshot](https://github.com/BeeQuantAI/platform_api/assets/80236130/5786f853-75a3-4cf9-a3c4-cb7ccb431e58)
![2024-06-15 11_24_37-Greenshot](https://github.com/BeeQuantAI/platform_api/assets/80236130/a70388ed-41f9-48d0-9541-ee2d93c9853e)
![2024-06-15 11_28_22-Greenshot](https://github.com/BeeQuantAI/platform_api/assets/80236130/2a6a2926-b67c-45e7-a0ce-69e08102cd92)
