### PR TITLE
feat: solve ERR_HTTP_HEADERS_SENT

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,8 +9,6 @@ import { UserModule } from './modules/user/user.module';
 import { ExchangeKeyModule } from './modules/exchangeKey/exchangeKey.module';
 import getConfig from './config';
 import { AuthModule } from './modules/auth/auth.module';
-import { APP_FILTER } from '@nestjs/core';
-import { AllExceptionsFilter } from './global-exception.filter';
 
 @Module({
   imports: [
@@ -36,6 +34,7 @@ import { AllExceptionsFilter } from './global-exception.filter';
         const errorMessage = {
           message: error.message,
           path: error.path,
+          extensions: error.extensions,
         };
         return errorMessage;
       },
@@ -47,10 +46,6 @@ import { AllExceptionsFilter } from './global-exception.filter';
   controllers: [AppController],
   providers: [
     AppService,
-    {
-      provide: APP_FILTER,
-      useClass: AllExceptionsFilter,
-    },
   ],
 })
 export class AppModule {}

--- a/src/global-exception.filter.ts
+++ b/src/global-exception.filter.ts
@@ -1,8 +1,0 @@
-import { Catch, ExceptionFilter, ArgumentsHost } from '@nestjs/common';
-
-@Catch()
-export class AllExceptionsFilter implements ExceptionFilter {
-  catch(exception: any, host: ArgumentsHost) {
-    //TODO: Investigate: Error: Cannot set headers after they are sent to the client,  code: 'ERR_HTTP_HEADERS_SENT'
-  }
-}

--- a/src/modules/auth/filter/register-pipe-error.filter.ts
+++ b/src/modules/auth/filter/register-pipe-error.filter.ts
@@ -1,38 +1,34 @@
 import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
 import { GqlArgumentsHost } from '@nestjs/graphql';
-import { NOT_EMPTY, VALIDATE_ERROR } from '@/common/constants/code';
+import { NOT_EMPTY, VALIDATE_ERROR, UNKNOWN_ERROR } from '@/common/constants/code';
 import { EmptyFiledException } from '@/exceptions/empty-field.exception';
 import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { GraphQLError } from 'graphql';
 
 @Catch(EmptyFiledException, InvalidInputException)
 export class RegisterPipeErrorFilter implements ExceptionFilter {
   catch(exception: EmptyFiledException | InvalidInputException, host: ArgumentsHost) {
     const gqlHost = GqlArgumentsHost.create(host);
     const ctx = gqlHost.getContext();
-    const response = ctx.req.res;
+    let errorCode: number;
+    let errorMessage: string;
 
-    if (exception instanceof EmptyFiledException) {
-      response.json({
-        data: {
-          register: {
-            code: NOT_EMPTY,
-            message: exception.message,
-            data: null,
-          },
-        },
-      });
+    switch (exception.constructor) {
+      case EmptyFiledException:
+        errorCode = NOT_EMPTY;
+        errorMessage = exception.message;
+        break;
+      case InvalidInputException:
+        errorCode = VALIDATE_ERROR;
+        errorMessage = exception.message;
+        break;
+      default:
+        errorCode = UNKNOWN_ERROR;
+        errorMessage = exception.message;
     }
 
-    if (exception instanceof InvalidInputException) {
-      response.json({
-        data: {
-          register: {
-            code: VALIDATE_ERROR,
-            message: exception.message,
-            data: null,
-          },
-        },
-      });
-    }
+    throw new GraphQLError(errorMessage, {
+      extensions: { code: errorCode },
+    });
   }
 }


### PR DESCRIPTION
card requirement:
Investigate the cause of "Error: Cannot set headers after they are sent to the client,  code: 'ERR_HTTP_HEADERS_SENT'" without global filter when the "email" value is "" in register mutation. and find if there’s any better solution.

completed:
- cause by response.json in RegisterPipeErrorFilter overwrite the response that managed by graphQL and Apollo
- now throw GraphQLError to add error code to response in a graphQL standard rather than REST API standard
- refer to https://www.apollographql.com/docs/apollo-server/migration/#apolloerror

![Screenshot 2024-07-02 at 7 43 36 PM](https://github.com/BeeQuantAI/platform_api/assets/84086904/01234b10-55b7-41cf-9a0e-d4b443dafd7c)

<img width="1459" alt="Screenshot 2024-07-02 at 7 43 44 PM" src="https://github.com/BeeQuantAI/platform_api/assets/84086904/e45ff97f-368f-427e-8727-5b06ce36acad">
