### PR TITLE
refactor: remove redundant code from user resolver

### DIFF
--- a/src/modules/user/user.resolver.ts
+++ b/src/modules/user/user.resolver.ts
@@ -3,7 +3,6 @@ import { CreateUserInput } from './dto/new-user.input';
 import { UserType } from './dto/user.type';
 import { UserService } from './user.service';
 import { UpdateUserInput } from './dto/update-user.input';
-import { SkipAuth } from '../auth/skip-auth.decorator';
 import { GqlAuthGuard } from '@/common/guards/auth.guard';
 import { UseGuards } from '@nestjs/common';
 
@@ -33,7 +32,6 @@ export class UserResolver {
     return await this.userService.find(id);
   }
 
-  @SkipAuth()
   @Mutation(() => Boolean, { description: 'Create new user' })
   async createUser(@Args('input') input: CreateUserInput): Promise<boolean> {
     return await this.userService.create(input);


### PR DESCRIPTION
**card requirement:**
Remove redundant code: test whether the `@SkipAuth()` decorator on the `createUser` mutation in the user resolver is unnecessary and can be safely removed without affecting the functionality of the authentication system.
<img width="648" alt="14f6c1df-ea97-4004-b211-8829dbdcf48d" src="https://github.com/user-attachments/assets/c5839058-a4f2-4c53-bc38-92b3e01693de">


**completed:**
- After removing the decorator, I tested in the GraphQL Apollo service playground by calling the `createUser` Mutation and `Register` Mutation without passing any headers. The user could be created successfully.
<img width="1012" alt="createUser" src="https://github.com/user-attachments/assets/c058cb8b-2716-402f-9ddf-b3b7e614e29c">
<img width="1168" alt="Register" src="https://github.com/user-attachments/assets/1b658771-dac9-4333-90ff-35929dc00156">

- The newly added data could also be seen in the database.
![database](https://github.com/user-attachments/assets/54a1fbec-5fb6-488f-8803-25c933e3ae2f)

- No functionality was affected, and all existing tests passed.
<img width="528" alt="testing" src="https://github.com/user-attachments/assets/408ca1f5-5b07-4b99-a9ff-c3d0469728f7">


**Resolve CP-87**

