### PR TITLE
fix: fix validation pipe's wrong condition logic

### DIFF
--- a/src/modules/auth/pipe/registration-validation.pipe.spec.ts
+++ b/src/modules/auth/pipe/registration-validation.pipe.spec.ts
@@ -1,54 +1,66 @@
+import { InvalidInputException } from './../../../exceptions/invalid-input.exception';
 import { ValidationPipe } from './registration-validation.pipe';
 import { userSchema } from '../../../validation/schemas/auth/user.request';
+import { EmptyFiledException } from '@/exceptions/empty-field.exception';
 
 describe('ValidationPipe', () => {
   let pipe: ValidationPipe;
 
-  beforeEach(() => {
+  const validData = {
+    displayName: 'test',
+    email: 'test@example.com',
+    password: 'password123!',
+    ref: 'ADMIN',
+  };
+
+  beforeAll(() => {
     pipe = new ValidationPipe(userSchema);
   });
 
   it('should transform value if validation passes', () => {
-    const value = {
-      displayName: 'test',
-      email: 'test@example.com',
-      password: 'password123!',
-      ref: 'COREINTERNAL',
-    };
-
-    expect(pipe.transform(value)).toEqual(value);
+    expect(pipe.transform(validData)).toEqual(validData);
   });
 
-  it('should throw HttpException if validation fails', () => {
-    const value = {
-      displayName: 'te',
-      email: 'test@example',
-      password: 'password123!',
-    };
+  it('should pass when displayName is empty', () => {
+    const value = { ...validData, displayName: '' };
+    expect(() => pipe.transform(value)).not.toThrow();
+  });
 
+  it('should throw EmptyFiledException if email is empty', () => {
+    const value = { ...validData, email: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow('"email" is required');
+  });
+
+  it('should throw EmptyFiledException if password is empty', () => {
+    const value = { ...validData, password: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow('"password" is required');
+  });
+
+  it('should throw InvalidInputException with customized error message if email is not valid', () => {
+    const value = { ...validData, email: '123' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow('"email" must be a valid email');
+  });
+
+  it('should throw InvalidInputException with default error message if password is not valid', () => {
+    const value = { ...validData, password: 'sh1' };
     try {
-      pipe.transform(value);
-      fail('Expected HttpException to be thrown');
-    } catch (error) {
-      expect(error.message).toEqual(
-        '"Display Name" with value "te" fails to match the required pattern: /^([a-zA-Z0-9-_]{4,15})?$/'
-      );
-      expect(error.getStatus()).toEqual(400);
+      expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    } catch (e) {
+      const message = e.message;
+      expect(() => pipe.transform(value)).toThrow(message);
     }
   });
 
-  it('should throw HttpException if validation fails', () => {
-    const value = {
-      displayName: '',
-      email: '',
-      password: 'password123!',
-    };
-
+  it('should throw InvalidInputException with default error message if displayName is not valid', () => {
+    const value = { ...validData, displayName: '22' };
     try {
-      pipe.transform(value);
-      fail('Expected HttpException to be thrown');
-    } catch (error) {
-      expect(error.getStatus()).toEqual(400);
+      expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    } catch (e) {
+      const message = e.message;
+      expect(() => pipe.transform(value)).toThrow(message);
     }
   });
 });


### PR DESCRIPTION
Added 
- errorMatcher function taking three parameters(path, type, message) to throw responding exceptions
- compared with previous codes,  add two validation rules instead of directly throwing the default Joi error, which could not be caught by the registration-validation pipe 
- 1. when the password does not match the pattern defined throw InvalidaInputException, 
- 2. when the email does not match the validation throw InvalidaInputException
Refactor
- registration-validation-test, to test in different scenarios the pipe would throw corresponding exceptions with either customized or default error messages. 

Resolve CP-89

SceenShot:
1、empty email return code 1006
<img width="1870" alt="image" src="https://github.com/user-attachments/assets/3ff8ab48-b7ac-45f4-b773-8c747540e671">
2、invalid email return code 1007
<img width="1239" alt="image" src="https://github.com/user-attachments/assets/381030a2-f5aa-46fa-b2cd-1a8792fa96cd">
3、empty password return code 1006
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/764cbd93-9e4f-4800-be5f-4ad28f1c51a6">
4、invalid password return 1007 and customized message
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/344690b3-7531-4532-9191-e986d11011f1">
5、invalid displayName return 1007 and customized message
<img width="1216" alt="image" src="https://github.com/user-attachments/assets/ec6f2f97-0baf-45e1-8e78-c8aac87b9cb7">

Test Result:
![9591722052547_ pic](https://github.com/user-attachments/assets/7861c221-50d1-4fdf-af4b-993d69127d63)
