### PR TITLE
Refactor: refactor password validation pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "type-graphql": "^1.1.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/common/utils/errorMatcher.ts
+++ b/src/common/utils/errorMatcher.ts
@@ -1,0 +1,31 @@
+import { EmptyFiledException } from '@/exceptions/empty-field.exception';
+import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { BadRequestException, HttpException } from '@nestjs/common';
+import { z } from 'zod';
+
+type errorMatcherProps = {
+  code: z.ZodIssueCode;
+  message?: string;
+  min?: number;
+};
+
+const actions = {
+  invalid_string: (message: string) => {
+    throw new InvalidInputException(message);
+  },
+  too_small: (message: string, min: number) => {
+    throw min === 1 ? new EmptyFiledException(message) : new InvalidInputException(message);
+  },
+  too_big: (message: string) => {
+    throw new InvalidInputException(message);
+  },
+};
+
+export function errorMatcher({ code, message, min }: errorMatcherProps): HttpException {
+  for (const key in actions) {
+    if (key === code) {
+      return actions[key](message, min);
+    }
+  }
+  throw new BadRequestException(message);
+}

--- a/src/common/utils/helpers.ts
+++ b/src/common/utils/helpers.ts
@@ -1,3 +1,84 @@
-export const displayNamePatten = /^([a-zA-Z0-9-_]{4,15})?$/;
-export const passwordPatten =
-  /^(?=.*[A-Za-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*_+=\\~<>:;”’(),./[\]_`|{}-])[A-Za-z0-9#?!@$%^&*_+=\\~<>:;”’(),./[\]_`|{}-]{8,32}$/;
+import * as z from 'zod';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+// Error messages
+export enum DisplayErrorMsgs {
+  Required = 'Display name is required',
+  MinLength = 'Display name must be at least 4 characters',
+  MaxLength = 'Display name must be at most 15 characters',
+  Invalid = 'Display name must contain only letters, numbers, hyphens and underscores',
+}
+
+export enum EmailErrorMsgs {
+  Required = 'Email is required',
+  Invalid = 'Invalid email address',
+}
+
+export enum PasswordErrorMsgs {
+  Required = 'Password is required',
+  MinLength = 'Password must be at least 8 characters',
+  MaxLength = 'Password must be at most 32 characters',
+  Invalid = 'Password must contain at least one letter, one number and one special character',
+}
+
+export enum RefErrorMsgs {
+  Required = 'Referral code is required',
+}
+
+export enum PasswordCompareErrorMsgs {
+  NotMatch = 'Passwords do not match',
+}
+
+export enum PasswordUpdateErrorMsgs {
+  OldPasswordRequired = 'Old password is required',
+  NewPasswordRequired = 'New password is required',
+}
+
+export const displayNameSchema = z.union([
+  z
+    .string()
+    .min(4, { message: DisplayErrorMsgs.MinLength })
+    .max(15, { message: DisplayErrorMsgs.MaxLength })
+    .regex(/^[a-zA-Z0-9-_]+$/, {
+      message: DisplayErrorMsgs.Invalid,
+    }),
+  z
+    .string()
+    .length(0)
+    .transform(() => process.env.DEFAULT_DISPLAY_NAME || 'New User'),
+]);
+
+const commonPasswordSchema = z
+  .string()
+  .min(8, { message: PasswordErrorMsgs.MinLength })
+  .max(32, { message: PasswordErrorMsgs.MaxLength })
+  .regex(
+    /^(?=.*[A-Za-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*_+=\\~<>:;”’(),./[\]_`|{}-])[A-Za-z0-9#?!@$%^&*_+=\\~<>:;”’(),./[\]_`|{}-]+$/,
+    { message: PasswordErrorMsgs.Invalid }
+  );
+
+export const passwordSchema = z
+  .string()
+  .min(1, { message: PasswordErrorMsgs.Required })
+  .and(commonPasswordSchema);
+
+export const newPasswordSchema = z
+  .string()
+  .min(1, { message: PasswordUpdateErrorMsgs.NewPasswordRequired })
+  .and(commonPasswordSchema);
+
+export const oldPasswordSchema = z
+  .string()
+  .min(1, { message: PasswordUpdateErrorMsgs.OldPasswordRequired })
+  .and(commonPasswordSchema);
+
+export const emailSchema = z
+  .string()
+  .min(1, { message: EmailErrorMsgs.Required })
+  .email({ message: EmailErrorMsgs.Invalid });
+
+export const refSchema = z
+  .string()
+  .optional()
+  .default(process.env.DEFAULT_REFERENCE || 'Default_Reference_Name');

--- a/src/modules/auth/auth.resolver.ts
+++ b/src/modules/auth/auth.resolver.ts
@@ -29,8 +29,8 @@ export class AuthResolver {
   }
 
   @Mutation(() => Result, { description: 'Change password' })
-  @UseFilters(PasswordPipeErrorFilter)
   @UseGuards(GqlAuthGuard)
+  @UseFilters(PasswordPipeErrorFilter)
   async changePassword(
     @Context() cxt: { req: Partial<Request> & { user: { id: string } } },
     @Args('input', new PasswordValidationPipe(passwordUpdateSchema)) input: UpdatePasswordInput

--- a/src/modules/auth/filter/password-pipe-error.filter.ts
+++ b/src/modules/auth/filter/password-pipe-error.filter.ts
@@ -1,38 +1,31 @@
-import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
-import { GqlArgumentsHost } from '@nestjs/graphql';
-import { NOT_EMPTY, VALIDATE_ERROR } from '@/common/constants/code';
+import { Catch, ExceptionFilter } from '@nestjs/common';
+import { NOT_EMPTY, UNKNOWN_ERROR, VALIDATE_ERROR } from '@/common/constants/code';
 import { EmptyFiledException } from '@/exceptions/empty-field.exception';
 import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { GraphQLError } from 'graphql';
 
 @Catch(EmptyFiledException, InvalidInputException)
 export class PasswordPipeErrorFilter implements ExceptionFilter {
-  catch(exception: EmptyFiledException | InvalidInputException, host: ArgumentsHost) {
-    const gqlHost = GqlArgumentsHost.create(host);
-    const ctx = gqlHost.getContext();
-    const response = ctx.req.res;
+  catch(exception: EmptyFiledException | InvalidInputException) {
+    let errorCode: number;
+    let errorMessage: string;
 
-    if (exception instanceof EmptyFiledException) {
-      response.json({
-        data: {
-          changePassword: {
-            code: NOT_EMPTY,
-            message: exception.message,
-            data: null,
-          },
-        },
-      });
+    switch (exception.constructor) {
+      case EmptyFiledException:
+        errorCode = NOT_EMPTY;
+        errorMessage = exception.message;
+        break;
+      case InvalidInputException:
+        errorCode = VALIDATE_ERROR;
+        errorMessage = exception.message;
+        break;
+      default:
+        errorCode = UNKNOWN_ERROR;
+        errorMessage = exception.message;
     }
 
-    if (exception instanceof InvalidInputException) {
-      response.json({
-        data: {
-          changePassword: {
-            code: VALIDATE_ERROR,
-            message: exception.message,
-            data: null,
-          },
-        },
-      });
-    }
+    throw new GraphQLError(errorMessage, {
+      extensions: { code: errorCode },
+    });
   }
 }

--- a/src/modules/auth/filter/register-pipe-error.filter.ts
+++ b/src/modules/auth/filter/register-pipe-error.filter.ts
@@ -1,5 +1,4 @@
-import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
-import { GqlArgumentsHost } from '@nestjs/graphql';
+import { Catch, ExceptionFilter } from '@nestjs/common';
 import { NOT_EMPTY, VALIDATE_ERROR, UNKNOWN_ERROR } from '@/common/constants/code';
 import { EmptyFiledException } from '@/exceptions/empty-field.exception';
 import { InvalidInputException } from '@/exceptions/invalid-input.exception';
@@ -7,12 +6,9 @@ import { GraphQLError } from 'graphql';
 
 @Catch(EmptyFiledException, InvalidInputException)
 export class RegisterPipeErrorFilter implements ExceptionFilter {
-  catch(exception: EmptyFiledException | InvalidInputException, host: ArgumentsHost) {
-    const gqlHost = GqlArgumentsHost.create(host);
-    const ctx = gqlHost.getContext();
+  catch(exception: EmptyFiledException | InvalidInputException) {
     let errorCode: number;
     let errorMessage: string;
-
     switch (exception.constructor) {
       case EmptyFiledException:
         errorCode = NOT_EMPTY;

--- a/src/modules/auth/pipe/password-validation.pipe.spec.ts
+++ b/src/modules/auth/pipe/password-validation.pipe.spec.ts
@@ -2,6 +2,7 @@ import { PasswordValidationPipe } from './password-validation.pipe';
 import { passwordUpdateSchema } from '@/validation/schemas/auth/password.update';
 import { EmptyFiledException } from '@/exceptions/empty-field.exception';
 import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { PasswordErrorMsgs, PasswordUpdateErrorMsgs } from '@/common/utils/helpers';
 
 describe('PasswordValidationPipe', () => {
   let pipe: PasswordValidationPipe;
@@ -24,7 +25,7 @@ describe('PasswordValidationPipe', () => {
       newPassword: 'newPass123!',
     };
     expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
-    expect(() => pipe.transform(value)).toThrow('"Old Password" is required');
+    expect(() => pipe.transform(value)).toThrow(PasswordUpdateErrorMsgs.OldPasswordRequired);
   });
 
   it('should throw EmptyFiledException when newPassword is missing', () => {
@@ -33,28 +34,42 @@ describe('PasswordValidationPipe', () => {
       newPassword: '',
     };
     expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
-    expect(() => pipe.transform(value)).toThrow('"New Password" is required');
+    expect(() => pipe.transform(value)).toThrow(PasswordUpdateErrorMsgs.NewPasswordRequired);
+  });
+
+  it('should throw InvalidInputException when newPassword is too short', () => {
+    const value = {
+      oldPassword: 'invalid12!',
+      newPassword: 'validPa',
+    };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.MinLength);
+  });
+
+  it('should throw InvalidInputException when newPassword is too long', () => {
+    const value = {
+      oldPassword: 'invalid12!',
+      newPassword: 'validPaabcedfs01234567890!!abcdefghi0123',
+    };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.MaxLength);
   });
 
   it('should throw InvalidInputException when oldPassword does not match pattern', () => {
     const value = {
-      oldPassword: 'invalid',
+      oldPassword: 'invalid12',
       newPassword: 'validPass123!',
     };
     expect(() => pipe.transform(value)).toThrow(InvalidInputException);
-    expect(() => pipe.transform(value)).toThrow(
-      'Validation failed: password must contain 8 to 32 characters, including letter, number and special character.'
-    );
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.Invalid);
   });
 
   it('should throw InvalidInputException when newPassword does not match pattern', () => {
     const value = {
       oldPassword: 'validPass123!',
-      newPassword: 'invalid',
+      newPassword: 'invalid12',
     };
     expect(() => pipe.transform(value)).toThrow(InvalidInputException);
-    expect(() => pipe.transform(value)).toThrow(
-      'Validation failed: password must contain 8 to 32 characters, including letter, number and special character.'
-    );
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.Invalid);
   });
 });

--- a/src/modules/auth/pipe/password-validation.pipe.ts
+++ b/src/modules/auth/pipe/password-validation.pipe.ts
@@ -1,33 +1,23 @@
-import { Injectable, PipeTransform, BadRequestException } from '@nestjs/common';
-import * as Joi from 'joi';
-import { EmptyFiledException } from '@/exceptions/empty-field.exception';
-import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { z, ZodIssue, ZodSchema } from 'zod';
+import { errorMatcher } from '@/common/utils/errorMatcher';
 
 @Injectable()
 export class PasswordValidationPipe implements PipeTransform {
-  constructor(private schema: Joi.ObjectSchema) {}
-  transform(value: any) {
-    const { error } = this.schema.validate(value);
-    if (error) {
-      if (
-        error.message === '"Old Password" is required' ||
-        error.message === '"New Password" is required'
-      ) {
-        throw new EmptyFiledException(error.message);
+  constructor(private schema: ZodSchema) {}
+  transform(value: unknown) {
+    try {
+      const parsedValue = this.schema.parse(value);
+      return parsedValue;
+    } catch (error) {
+      const issues: ZodIssue = error.issues;
+      const code: z.ZodIssueCode = issues[0].code;
+      const message: string = issues[0].message;
+      if (code === 'too_small') {
+        const min: number = issues[0].minimum;
+        return errorMatcher({ code, message, min });
       }
-      if (
-        error.message.match(
-          /^"Old Password" with value.*fails to match the required pattern: .*/
-        ) ||
-        error.message.match(/^"New Password" with value.*fails to match the required pattern: .*/)
-      ) {
-        throw new InvalidInputException(
-          'Validation failed: password must contain 8 to 32 characters, ' +
-            'including letter, number and special character.'
-        );
-      }
-      throw new BadRequestException(`Validation failed: ${error.message}`);
+      return errorMatcher({ code, message });
     }
-    return value;
   }
 }

--- a/src/modules/auth/pipe/registration-validation.pipe.spec.ts
+++ b/src/modules/auth/pipe/registration-validation.pipe.spec.ts
@@ -2,6 +2,7 @@ import { InvalidInputException } from './../../../exceptions/invalid-input.excep
 import { ValidationPipe } from './registration-validation.pipe';
 import { userSchema } from '../../../validation/schemas/auth/user.request';
 import { EmptyFiledException } from '@/exceptions/empty-field.exception';
+import { DisplayErrorMsgs, EmailErrorMsgs, PasswordErrorMsgs } from '@/common/utils/helpers';
 
 describe('ValidationPipe', () => {
   let pipe: ValidationPipe;
@@ -29,38 +30,54 @@ describe('ValidationPipe', () => {
   it('should throw EmptyFiledException if email is empty', () => {
     const value = { ...validData, email: '' };
     expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
-    expect(() => pipe.transform(value)).toThrow('"email" is required');
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Required);
   });
 
   it('should throw EmptyFiledException if password is empty', () => {
     const value = { ...validData, password: '' };
     expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
-    expect(() => pipe.transform(value)).toThrow('"password" is required');
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.Required);
   });
 
-  it('should throw InvalidInputException with customized error message if email is not valid', () => {
+  it('should throw InvalidInputException with invalid error message if email is not valid', () => {
     const value = { ...validData, email: '123' };
     expect(() => pipe.transform(value)).toThrow(InvalidInputException);
-    expect(() => pipe.transform(value)).toThrow('"email" must be a valid email');
+    expect(() => pipe.transform(value)).toThrow(EmailErrorMsgs.Invalid);
   });
 
-  it('should throw InvalidInputException with default error message if password is not valid', () => {
+  it('should throw InvalidInputException with invalid error message if password is not valid', () => {
+    const value = { ...validData, password: '123452362' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException with invalid error message if displayName is not valid', () => {
+    const value = { ...validData, displayName: 'ab12!' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.Invalid);
+  });
+
+  it('should throw InvalidInputException with minLength error message if password is too short', () => {
     const value = { ...validData, password: 'sh1' };
-    try {
-      expect(() => pipe.transform(value)).toThrow(InvalidInputException);
-    } catch (e) {
-      const message = e.message;
-      expect(() => pipe.transform(value)).toThrow(message);
-    }
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.MinLength);
   });
 
-  it('should throw InvalidInputException with default error message if displayName is not valid', () => {
+  it('should throw InvalidInputException with maxLength error message if password is too long', () => {
+    const value = { ...validData, password: 'abcdefghigklmn0123456790qwer!@#$%' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(PasswordErrorMsgs.MaxLength);
+  });
+
+  it('should throw InvalidInputException with minLength error message if displayName is not short', () => {
     const value = { ...validData, displayName: '22' };
-    try {
-      expect(() => pipe.transform(value)).toThrow(InvalidInputException);
-    } catch (e) {
-      const message = e.message;
-      expect(() => pipe.transform(value)).toThrow(message);
-    }
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.MinLength);
+  });
+
+  it('should throw InvalidInputException with maxLength error message if displayName is not long', () => {
+    const value = { ...validData, displayName: 'seiseijia-australia' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.MaxLength);
   });
 });

--- a/src/modules/auth/pipe/registration-validation.pipe.ts
+++ b/src/modules/auth/pipe/registration-validation.pipe.ts
@@ -1,33 +1,24 @@
-import { Injectable, PipeTransform, BadRequestException } from '@nestjs/common';
-import * as Joi from 'joi';
-import { EmptyFiledException } from '../../../exceptions/empty-field.exception';
-import { InvalidInputException } from '../../../exceptions/invalid-input.exception';
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { errorMatcher } from '@/common/utils/errorMatcher';
+import { z, ZodIssue, ZodSchema } from 'zod';
 
 @Injectable()
 export class ValidationPipe implements PipeTransform {
-  constructor(private schema: Joi.ObjectSchema) {}
+  constructor(private schema: ZodSchema) {}
 
-  transform(value: any) {
-    const { error, value: validatedValue } = this.schema.validate(value);
-    if (error) {
-      const path = error.details[0].path[0];
-      const type = error.details[0].type;
-      const message = error.details[0].message;
-      this.errorMatcher(path, type, message);
-    }
-    return validatedValue;
-  }
-
-  private errorMatcher(path, type, message) {
-    switch (type) {
-      case 'string.pattern.base':
-        throw new InvalidInputException(message);
-      case 'any.required':
-        throw new EmptyFiledException(`"${path}" is required`);
-      case 'string.email':
-        throw new InvalidInputException(`"${path}" must be a valid email`);
-      default:
-        throw new BadRequestException(message);
+  transform(value: unknown) {
+    try {
+      const parsedValue = this.schema.parse(value);
+      return parsedValue;
+    } catch (error) {
+      const issues: ZodIssue = error.issues;
+      const code: z.ZodIssueCode = issues[0].code;
+      const message: string = issues[0].message;
+      if (code === 'too_small') {
+        const min: number = issues[0].minimum;
+        return errorMatcher({ code, message, min });
+      }
+      return errorMatcher({ code, message });
     }
   }
 }

--- a/src/validation/schemas/auth/password.update.spec.ts
+++ b/src/validation/schemas/auth/password.update.spec.ts
@@ -11,24 +11,24 @@ describe('passwordUpdateSchema', () => {
       oldPassword: validPassword,
       newPassword: validPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeUndefined();
+    const validatedData = passwordUpdateSchema.parse(data);
+    expect(validatedData).toEqual(data);
   });
 
   it('should fail when oldPassword is missing', () => {
     const data = {
       newPassword: validPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 
   it('should fail when newPassword is missing', () => {
     const data = {
       oldPassword: validPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 
   it('should fail when oldPassword does not match pattern', () => {
@@ -36,8 +36,8 @@ describe('passwordUpdateSchema', () => {
       oldPassword: invalidPassword,
       newPassword: validPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 
   it('should fail when newPassword does not match pattern', () => {
@@ -45,8 +45,8 @@ describe('passwordUpdateSchema', () => {
       oldPassword: validPassword,
       newPassword: invalidPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 
   it('should fail when oldPassword is empty', () => {
@@ -54,8 +54,8 @@ describe('passwordUpdateSchema', () => {
       oldPassword: '',
       newPassword: validPassword,
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 
   it('should fail when newPassword is empty', () => {
@@ -63,7 +63,7 @@ describe('passwordUpdateSchema', () => {
       oldPassword: validPassword,
       newPassword: '',
     };
-    const { error } = passwordUpdateSchema.validate(data);
-    expect(error).toBeDefined();
+    const result = passwordUpdateSchema.safeParse(data);
+    expect(result.success).toBe(false);
   });
 });

--- a/src/validation/schemas/auth/password.update.ts
+++ b/src/validation/schemas/auth/password.update.ts
@@ -1,9 +1,7 @@
-import * as Joi from 'joi';
-import { passwordPatten } from '@/common/utils/helpers';
-import * as dotenv from 'dotenv';
-dotenv.config();
+import { newPasswordSchema, oldPasswordSchema } from '@/common/utils/helpers';
+import * as z from 'zod';
 
-export const passwordUpdateSchema = Joi.object({
-  oldPassword: Joi.string().pattern(passwordPatten).required().empty('').label('Old Password'),
-  newPassword: Joi.string().pattern(passwordPatten).required().empty('').label('New Password'),
+export const passwordUpdateSchema = z.object({
+  oldPassword: oldPasswordSchema,
+  newPassword: newPasswordSchema,
 });

--- a/src/validation/schemas/auth/user.request.spec.ts
+++ b/src/validation/schemas/auth/user.request.spec.ts
@@ -1,84 +1,55 @@
 import { userSchema } from './user.request';
 import * as dotenv from 'dotenv';
 dotenv.config();
-const envReference = process.env.DEFAULT_REFERENCE;
+const envRef = process.env.DEFAULT_REFERENCE;
 const envDisplayName = process.env.DEFAULT_DISPLAY_NAME;
 
 describe('userSchema', () => {
+  const validateData = {
+    displayName: '',
+    email: 'test@example.com',
+    password: 'Test123!',
+  };
+
   it('should allow displayName being empty', () => {
-    const result = userSchema.validate({
-      displayName: '',
-      email: 'test@example.com',
-      password: 'Test123!',
-    });
-    expect(result.error).toBeFalsy();
-    expect(result.value.displayName).toBe(envDisplayName || 'New User');
+    const result = userSchema.safeParse(validateData);
+    expect(result.success).toEqual(true);
+    expect(result.data.displayName).toBe(envDisplayName || 'New User');
   });
 
   it('should validate displayName correctly, when displayName is valid', () => {
-    const result = userSchema.validate({
-      displayName: 'testUser',
-      email: 'test@example.com',
-      password: 'Test123!',
-    });
-    expect(result.error).toBeFalsy();
-    expect(result.value.displayName).toBe('testUser');
+    const data = { ...validateData, displayName: 'testUser' };
+    const result = userSchema.safeParse(data);
+    expect(result.success).toEqual(true);
   });
 
   it('should validate displayName correctly, when displayName is invalid', () => {
-    const result = userSchema.validate({ displayName: 'a' });
-    expect(result.error).toBeTruthy();
+    const data = { ...validateData, displayName: 'a' };
+    const result = userSchema.safeParse(data);
+    expect(result.success).toEqual(false);
   });
 
   it('should validate email correctly, when email is empty', () => {
-    const result = userSchema.validate({ email: '' });
-    expect(result.error).toBeTruthy();
-  });
-
-  it('should validate email correctly, when email is valid', () => {
-    const validEmail = 'test@example.com';
-    const validResult = userSchema.validate({
-      email: validEmail,
-      displayName: 'testUser',
-      password: 'Test123!',
-    });
-    expect(validResult.error).toBeFalsy();
-    expect(validResult.value.email).toBe(validEmail);
+    const data = { ...validateData, email: '' };
+    const result = userSchema.safeParse(data);
+    expect(result.success).toEqual(false);
   });
 
   it('should validate password correctly, when password is empty', () => {
-    const result = userSchema.validate({ password: '' });
-    expect(result.error).toBeTruthy();
-  });
-
-  it('should validate password correctly, when password is valid', () => {
-    const validPassword = 'Test123!';
-    const validResult = userSchema.validate({
-      password: validPassword,
-      displayName: 'testUser',
-      email: 'test@example.com',
-    });
-    expect(validResult.error).toBeFalsy();
-    expect(validResult.value.password).toBe(validPassword);
+    const data = { ...validateData, password: '' };
+    const result = userSchema.safeParse(data);
+    expect(result.success).toEqual(false);
   });
 
   it('should validate password correctly, when password is invalid', () => {
-    const validPassword = 'Test1234';
-    const validResult = userSchema.validate({
-      password: validPassword,
-      displayName: 'testUser',
-      email: 'test@example.com',
-    });
-    expect(validResult.error).toBeTruthy();
+    const data = { ...validateData, password: 'test123' };
+    const result = userSchema.safeParse(data);
+    expect(result.success).toEqual(false);
   });
 
   it('should have default value for ref', () => {
-    const result = userSchema.validate({
-      email: 'test@example.com',
-      password: 'Test123!',
-    });
-
-    expect(result.error).toBeFalsy();
-    expect([envReference, 'Default_Reference_Name']).toContain(result.value.ref);
+    const result = userSchema.safeParse(validateData);
+    expect(result.success).toEqual(true);
+    expect(result.data.ref).toBe(envRef || 'Default_Reference_Name');
   });
 });

--- a/src/validation/schemas/auth/user.request.ts
+++ b/src/validation/schemas/auth/user.request.ts
@@ -1,17 +1,9 @@
-import * as Joi from 'joi';
-import { displayNamePatten, passwordPatten } from '@/common/utils/helpers';
-import * as dotenv from 'dotenv';
-dotenv.config();
+import * as z from 'zod';
+import { displayNameSchema, emailSchema, passwordSchema, refSchema } from '@/common/utils/helpers';
 
-export const userSchema = Joi.object({
-  displayName: Joi.string()
-    .pattern(displayNamePatten)
-    .empty('')
-    .default(process.env.DEFAULT_DISPLAY_NAME || 'New User')
-    .label('Display Name'),
-  email: Joi.string().email().required().empty('').label('Email'),
-  password: Joi.string().pattern(passwordPatten).required().empty('').label('Password'),
-  ref: Joi.string()
-    .empty('')
-    .default(process.env.DEFAULT_REFERENCE || 'Default_Reference_Name'),
+export const userSchema = z.object({
+  displayName: displayNameSchema,
+  email: emailSchema,
+  password: passwordSchema,
+  ref: refSchema,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6212,3 +6212,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.npmmirror.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
Refactor: refactor password validation pipe

Update
- make errorMatcher function shared between password and registration validation pipe
- update errorMatcher to catch zod validation errors into corresponding HttpException
- update password.update and user.request schema using zod library and responding test files
Refactor
- refactor password-validation and registration-validation pipe and their test files
Resolve CP-90

Postman Test:
1. registration:
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/a814d855-e1cd-4f60-ad65-a321fcc378ae">

2. update password:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/757e9673-144a-4915-8185-f09a1d3d8b9b">

test result:
1. registration
<img width="776" alt="image" src="https://github.com/user-attachments/assets/d0b232f7-ba55-4b2a-b3b1-48c0dfff5d15">

2. update password:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/cfb3bd0c-5ca2-483d-ac27-a399ac11bc28">
