### PR TITLE
fix:added display name field into the create exchange key API

### DIFF
--- a/src/common/utils/helpers.ts
+++ b/src/common/utils/helpers.ts
@@ -35,14 +35,22 @@ export enum PasswordUpdateErrorMsgs {
   NewPasswordRequired = 'New password is required',
 }
 
+export enum ExchangeKeyErrorMsgs {
+  ExchangeNameRequired = 'Exchange name is required',
+  AccessKeyRequired = 'Access key is required',
+  SecretKeyRequired = 'Secret key is required',
+}
+
+const commonDisplayNameSchema = z
+  .string()
+  .min(4, { message: DisplayErrorMsgs.MinLength })
+  .max(15, { message: DisplayErrorMsgs.MaxLength })
+  .regex(/^[a-zA-Z0-9-_]+$/, {
+    message: DisplayErrorMsgs.Invalid,
+  });
+
 export const displayNameSchema = z.union([
-  z
-    .string()
-    .min(4, { message: DisplayErrorMsgs.MinLength })
-    .max(15, { message: DisplayErrorMsgs.MaxLength })
-    .regex(/^[a-zA-Z0-9-_]+$/, {
-      message: DisplayErrorMsgs.Invalid,
-    }),
+  commonDisplayNameSchema,
   z
     .string()
     .length(0)
@@ -82,3 +90,20 @@ export const refSchema = z
   .string()
   .optional()
   .default(process.env.DEFAULT_REFERENCE || 'Default_Reference_Name');
+
+export const accessKeySchema = z
+  .string()
+  .min(1, { message: ExchangeKeyErrorMsgs.AccessKeyRequired });
+
+export const secretKeySchema = z
+  .string()
+  .min(1, { message: ExchangeKeyErrorMsgs.SecretKeyRequired });
+
+export const exchangeNameSchema = z
+  .string()
+  .min(1, { message: ExchangeKeyErrorMsgs.ExchangeNameRequired });
+
+export const exchangeKeyDisplayNameSchema = z.intersection(
+  z.string().min(1, { message: DisplayErrorMsgs.Required }),
+  commonDisplayNameSchema
+);

--- a/src/common/utils/pipeErrorHandler.ts
+++ b/src/common/utils/pipeErrorHandler.ts
@@ -1,0 +1,13 @@
+import { z, ZodIssue } from 'zod';
+import { errorMatcher } from './errorMatcher';
+
+export function pipeErrorHandler(error: any) {
+  const issues: ZodIssue = error.issues;
+  const code: z.ZodIssueCode = issues[0].code;
+  const message: string = issues[0].message;
+  if (code === 'too_small') {
+    const min: number = issues[0].minimum;
+    return errorMatcher({ code, message, min });
+  }
+  return errorMatcher({ code, message });
+}

--- a/src/modules/exchangeKey/dto/new-exchangeKey.input.ts
+++ b/src/modules/exchangeKey/dto/new-exchangeKey.input.ts
@@ -2,6 +2,8 @@ import { Field, InputType } from '@nestjs/graphql';
 
 @InputType()
 export class CreateExchangeKeyInput {
+  @Field({ description: 'Display name' })
+  displayName: string;
   @Field({ description: 'Exchange name' })
   exchangeName: string;
   @Field({ description: 'Access key' })

--- a/src/modules/exchangeKey/exchangeKey.resolver.ts
+++ b/src/modules/exchangeKey/exchangeKey.resolver.ts
@@ -1,9 +1,12 @@
 import { Args, Mutation, Resolver, Context } from '@nestjs/graphql';
 import { ExchangeKeyService } from './exchangeKey.service';
-import { UseGuards } from '@nestjs/common';
+import { UseFilters, UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '@/common/guards/auth.guard';
 import { Result } from '@/common/dto/result.type';
 import { CreateExchangeKeyInput } from './dto/new-exchangeKey.input';
+import { ExchangeKeyValidationPipe } from './pipe/exchangeKey-validation.pipe';
+import { exchangeKeyCreateSchema } from '@/validation/schemas/exchangeKey/exchangeKey.create';
+import { ExchangeKeyPipeErrorFilter } from './filter/exchangeKey-pipe-error.filter';
 
 @Resolver()
 @UseGuards(GqlAuthGuard)
@@ -11,9 +14,11 @@ export class ExchangeKeyResolver {
   constructor(private readonly exchangeKeyService: ExchangeKeyService) {}
 
   @Mutation(() => Result, { description: 'Create exchange key' })
+  @UseFilters(new ExchangeKeyPipeErrorFilter())
   async createExchangeKey(
     @Context() cxt,
-    @Args('input') input: CreateExchangeKeyInput
+    @Args('input', new ExchangeKeyValidationPipe(exchangeKeyCreateSchema))
+    input: CreateExchangeKeyInput
   ): Promise<Result> {
     const id = cxt.req.user.id;
     return await this.exchangeKeyService.createNewExchangeKey(id, input);

--- a/src/modules/exchangeKey/exchangeKey.service.spec.ts
+++ b/src/modules/exchangeKey/exchangeKey.service.spec.ts
@@ -22,6 +22,7 @@ describe('ExchangeKeyService', () => {
     secretKey: '456',
   } as ExchangeKey;
   const validExchangeKey = {
+    displayName: 'Binance Core',
     exchangeName: 'binance',
     accessKey: 'accesskey',
     secretKey: 'secretkey',

--- a/src/modules/exchangeKey/filter/exchangeKey-pipe-error.filter.ts
+++ b/src/modules/exchangeKey/filter/exchangeKey-pipe-error.filter.ts
@@ -1,0 +1,30 @@
+import { Catch, ExceptionFilter } from '@nestjs/common';
+import { NOT_EMPTY, VALIDATE_ERROR, UNKNOWN_ERROR } from '@/common/constants/code';
+import { EmptyFiledException } from '@/exceptions/empty-field.exception';
+import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+import { GraphQLError } from 'graphql';
+
+@Catch(EmptyFiledException, InvalidInputException)
+export class ExchangeKeyPipeErrorFilter implements ExceptionFilter {
+  catch(exception: EmptyFiledException | InvalidInputException) {
+    let errorCode: number;
+    let errorMessage: string;
+    switch (exception.constructor) {
+      case EmptyFiledException:
+        errorCode = NOT_EMPTY;
+        errorMessage = exception.message;
+        break;
+      case InvalidInputException:
+        errorCode = VALIDATE_ERROR;
+        errorMessage = exception.message;
+        break;
+      default:
+        errorCode = UNKNOWN_ERROR;
+        errorMessage = exception.message;
+    }
+
+    throw new GraphQLError(errorMessage, {
+      extensions: { code: errorCode },
+    });
+  }
+}

--- a/src/modules/exchangeKey/models/exchangeKey.entity.ts
+++ b/src/modules/exchangeKey/models/exchangeKey.entity.ts
@@ -5,6 +5,10 @@ import { Column, Entity, OneToMany } from 'typeorm';
 
 @Entity('PortalUserKey')
 export class ExchangeKey extends CommonEntity {
+  @Column({ comment: 'Display name' })
+  @IsNotEmpty()
+  displayName: string;
+
   @Column({
     comment: 'Access key',
   })

--- a/src/modules/exchangeKey/pipe/exchangeKey-validation.pipe.spec.ts
+++ b/src/modules/exchangeKey/pipe/exchangeKey-validation.pipe.spec.ts
@@ -1,0 +1,65 @@
+import { exchangeKeyCreateSchema } from '@/validation/schemas/exchangeKey/exchangeKey.create';
+import { ExchangeKeyValidationPipe } from './exchangeKey-validation.pipe';
+import { EmptyFiledException } from '@/exceptions/empty-field.exception';
+import { DisplayErrorMsgs, ExchangeKeyErrorMsgs } from '@/common/utils/helpers';
+import { InvalidInputException } from '@/exceptions/invalid-input.exception';
+
+describe('ExchangeKeyValidationPipe', () => {
+  let pipe: ExchangeKeyValidationPipe;
+
+  const validData = {
+    displayName: 'test',
+    exchangeName: 'binance',
+    accessKey: 'accessKey',
+    secretKey: 'secretKey',
+  };
+  beforeAll(() => {
+    pipe = new ExchangeKeyValidationPipe(exchangeKeyCreateSchema);
+  });
+
+  it('should transform value if validation passes', () => {
+    expect(pipe.transform(validData)).toEqual(validData);
+  });
+
+  it('should throw EmptyFiledException if displayName is empty', () => {
+    const value = { ...validData, displayName: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.Required);
+  });
+
+  it('should throw EmptyFiledException if exchangeName is empty', () => {
+    const value = { ...validData, exchangeName: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow(ExchangeKeyErrorMsgs.ExchangeNameRequired);
+  });
+
+  it('should throw EmptyFiledException if accessKey is empty', () => {
+    const value = { ...validData, accessKey: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow(ExchangeKeyErrorMsgs.AccessKeyRequired);
+  });
+
+  it('should throw EmptyFiledException if secretKey is empty', () => {
+    const value = { ...validData, secretKey: '' };
+    expect(() => pipe.transform(value)).toThrow(EmptyFiledException);
+    expect(() => pipe.transform(value)).toThrow(ExchangeKeyErrorMsgs.SecretKeyRequired);
+  });
+
+  it('should throw InvalidInputException with minLength error message if displayName is too short', () => {
+    const value = { ...validData, displayName: 'ab' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.MinLength);
+  });
+
+  it('should throw InvalidInputException with maxLength error message if displayName is too long', () => {
+    const value = { ...validData, displayName: 'BinanceExchangeOne' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.MaxLength);
+  });
+
+  it('should throw InvalidInputException if displayName is invalid', () => {
+    const value = { ...validData, displayName: '@binance' };
+    expect(() => pipe.transform(value)).toThrow(InvalidInputException);
+    expect(() => pipe.transform(value)).toThrow(DisplayErrorMsgs.Invalid);
+  });
+});

--- a/src/modules/exchangeKey/pipe/exchangeKey-validation.pipe.ts
+++ b/src/modules/exchangeKey/pipe/exchangeKey-validation.pipe.ts
@@ -1,0 +1,17 @@
+import { pipeErrorHandler } from '@/common/utils/pipeErrorHandler';
+import { PipeTransform, Injectable } from '@nestjs/common';
+import { ZodSchema } from 'zod';
+
+@Injectable()
+export class ExchangeKeyValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema) {}
+
+  transform(value: any) {
+    try {
+      const parsedValue = this.schema.parse(value);
+      return parsedValue;
+    } catch (error) {
+      return pipeErrorHandler(error);
+    }
+  }
+}

--- a/src/validation/schemas/exchangeKey/exchangeKey.create.spec.ts
+++ b/src/validation/schemas/exchangeKey/exchangeKey.create.spec.ts
@@ -1,0 +1,57 @@
+import { exchangeKeyCreateSchema } from './exchangeKey.create';
+
+describe('exchangeKeyCreateSchema', () => {
+  const validateExchangeKeyInput = {
+    displayName: 'test',
+    exchangeName: 'binance',
+    accessKey: 'accessKey',
+    secretKey: 'secretKey',
+  };
+
+  it('should fail when displayName is empty', () => {
+    const testInput = { ...validateExchangeKeyInput, displayName: '' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when exchangeName is less than 4 characters', () => {
+    const testInput = { ...validateExchangeKeyInput, displayName: 'bin' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when exchangeName is more than 15 characters', () => {
+    const testInput = { ...validateExchangeKeyInput, displayName: 'BinanceExchangeOne' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when exchangeName contains invalid characters', () => {
+    const testInput = { ...validateExchangeKeyInput, displayName: 'binance@' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when exchangeName is empty', () => {
+    const testInput = { ...validateExchangeKeyInput, exchangeName: '' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when accessKey is empty', () => {
+    const testInput = { ...validateExchangeKeyInput, accessKey: '' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should fail when secretKey is empty', () => {
+    const testInput = { ...validateExchangeKeyInput, secretKey: '' };
+    const result = exchangeKeyCreateSchema.safeParse(testInput);
+    expect(result.success).toBe(false);
+  });
+
+  it('should pass when all fields are valid', () => {
+    const result = exchangeKeyCreateSchema.safeParse(validateExchangeKeyInput);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/validation/schemas/exchangeKey/exchangeKey.create.ts
+++ b/src/validation/schemas/exchangeKey/exchangeKey.create.ts
@@ -1,0 +1,14 @@
+import {
+  accessKeySchema,
+  exchangeKeyDisplayNameSchema,
+  exchangeNameSchema,
+  secretKeySchema,
+} from '@/common/utils/helpers';
+import * as z from 'zod';
+
+export const exchangeKeyCreateSchema = z.object({
+  displayName: exchangeKeyDisplayNameSchema,
+  exchangeName: exchangeNameSchema,
+  accessKey: accessKeySchema,
+  secretKey: secretKeySchema,
+});


### PR DESCRIPTION
fix:added display name field into the create exchange key API
- added display name field into DTO and its corresponding service function
- added pipe and filter to validate the input value
- adjusted the relevant test file

added pipeErrorHandler to reuse duplicated code
added schemas related to exchange key validation rules

Resolve CP-132

Postman test:
![image](https://github.com/user-attachments/assets/a8ed24cf-9c2a-4893-81dc-db8fb7160125)

Unit test:
<img width="786" alt="image" src="https://github.com/user-attachments/assets/24050a4b-b567-4977-892a-13e6666c45c9">
