### PR TITLE
fix: hide stack error message

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,6 +40,7 @@ import { UserExchangeModule } from './modules/user-exchange/user-exchange.module
         };
         return errorMessage;
       },
+      includeStacktraceInErrorResponses: false,
     }),
     UserModule,
     AuthModule,


### PR DESCRIPTION
### Description:
Added ‘includeStacktraceInErrorResponses’ configuration in GraphQLModule to hide stack trace information in error responses

Resolve [CP-139](https://beequant.atlassian.net/browse/CP-139)

### Result:

For example, in 'Register' mutation, if I don't input the email field:
**Before:**
![image](https://github.com/user-attachments/assets/af913722-0fe0-478b-9523-1ab7272043fa)

**After:**
![image](https://github.com/user-attachments/assets/fb7558d1-5860-47b5-802a-c38ff8f8f934)